### PR TITLE
Multiple license plate formats

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
         "alpr": {
             "engine": "phantom",
             "guesses": 5,
-            "license_plate_format": ""
+            "license_plate_format": [""]
         },
         "alerts": {
             "alerts_ignore_validation": true,


### PR DESCRIPTION
As per feature request issue #6 these changes extends the validation system to support multiple license plate formats. Now users can input a comma-separated list of desired plate formats which the ALPR will validate against. Instead of checking against a single format, the system now iterates over multiple provided formats.

Improved user prompt for entering plate formats. Now, users will see all current formats as a comma-separated list, enhancing clarity and ease of modification.

This implementation has only been tested on pre-recorded video so far. It assumes that the user provides valid formats when prompted and does not input conflicting or erroneous formats. Future enhancements could add more in-depth user input validation.